### PR TITLE
Update example CDN URLs

### DIFF
--- a/index.md
+++ b/index.md
@@ -887,14 +887,14 @@ A typical setup might look something like the following, where we call `mocha.se
 <head>
   <meta charset="utf-8">
   <title>Mocha Tests</title>
-  <link href="https://cdn.rawgit.com/mochajs/mocha/2.2.4/mocha.css" rel="stylesheet" />
+  <link href="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.css" rel="stylesheet" />
 </head>
 <body>
   <div id="mocha"></div>
 
-  <script src="https://rawgit.com/jquery/jquery/2.1.4/dist/jquery.min.js"></script>
-  <script src="https://rawgit.com/Automattic/expect.js/0.3.1/index.js"></script>
-  <script src="https://cdn.rawgit.com/mochajs/mocha/2.2.4/mocha.js"></script>
+  <script src="https://cdn.rawgit.com/jquery/jquery/2.1.4/dist/jquery.min.js"></script>
+  <script src="https://cdn.rawgit.com/Automattic/expect.js/0.3.1/index.js"></script>
+  <script src="https://cdn.rawgit.com/mochajs/mocha/2.2.5/mocha.js"></script>
 
   <script>mocha.setup('bdd')</script>
   <script src="test.array.js"></script>


### PR DESCRIPTION
This updates `rawgit.com` examples to use `cdn.rawgit.com`.

It also updates Mocha's version to 2.2.5.
