### PR TITLE
Fix broken link to mocha-opts anchor tag

### DIFF
--- a/index.md
+++ b/index.md
@@ -60,7 +60,7 @@ Mocha is a feature-rich JavaScript test framework running on [Node.js](http://no
 - [Interfaces](#interfaces)
 - [Reporters](#reporters)
 - [Running Mocha in the Browser](#running-mocha-in-the-browser)
-- [`mocha.opts`](#mochaopts)
+- [`mocha.opts`](#mocha-opts)
 - [The `test/` Directory](#the-test-directory)
 - [Editor Plugins](#editor-plugins)
 - [Examples](#examples)


### PR DESCRIPTION
http://mochajs.org/#mochaopts doesn't work, but http://mochajs.org/#mocha-opts does.
