### PR TITLE
Remove recommendation for Node internal assert

### DIFF
--- a/index.md
+++ b/index.md
@@ -112,7 +112,7 @@ $  mocha
 
 ## Assertions
 
-Mocha allows you to use any assertion library you want, if it throws an error, it will work! This means you can utilize libraries such as [should.js](https://github.com/shouldjs/should.js), node's regular `assert` module, or others. The following is a list of known assertion libraries for node and/or the browser:
+Mocha allows you to use any assertion library you want, if it throws an error, it will work! This means you can utilize libraries such as:
 
 - [should.js](https://github.com/shouldjs/should.js) BDD style shown throughout these docs
 - [expect.js](https://github.com/LearnBoost/expect.js) expect() style assertions


### PR DESCRIPTION
Node.js has locked the internal `assert` API and has [updated documentation to encourage users to employ userland assertion libraries instead](https://github.com/nodejs/node/blob/0fc0902c21c9c9ed180e575f34b9b39366d57685/doc/api/assert.markdown). This removes a suggestion in the text that users use node's built-in `assert` API.

It's still there in three of the code examples. Would love to see those converted to `should` or something else, but I suspect part of the appeal of having examples with `assert` is that there's nothing extra to install etc.
