### PR TITLE
Use userland assertion library in code examples

### DIFF
--- a/index.md
+++ b/index.md
@@ -89,7 +89,7 @@ $ $EDITOR test/test.js
 In your editor:
 
 ```js
-var assert = require('assert');
+var assert = require('chai').assert;
 describe('Array', function() {
   describe('#indexOf()', function () {
     it('should return -1 when the value is not present', function () {
@@ -376,7 +376,7 @@ Given Mocha's use of `Function.prototype.call` and function expressions to defin
 Take the following example:
 
 ```js
-var assert = require('assert');
+var assert = require('chai').assert;
 
 function add() {
   return Array.prototype.slice.call(arguments).reduce(function(prev, curr) {
@@ -716,7 +716,7 @@ The `require` interface allows you to require the `describe` and friend words di
 var testCase = require('mocha').describe;
 var pre = require('mocha').before;
 var assertions = require('mocha').it;
-var assert = require('assert');
+var assert = require('chai').assert;
 
 testCase('Array', function() {
   pre(function() {


### PR DESCRIPTION
As pointed out by @Trott, "Node.js has locked the internal assert API
and has updated documentation to encourage users to employ userland
assertion libraries instead." http://git.io/v8WWl

It makes sense for us to update the code examples using a userland
assertion library. I chose `chai` because its assert API mimics node's
`assert`, and therefore I only\* needed to change the required library.
