### PR TITLE
Fix border bug in feature columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -126,6 +126,9 @@ ul li {
   border-bottom: 1px solid #eee;
   padding: 5px 0;
   font-size: 12px;
+  -webkit-column-break-inside: avoid;
+  -moz-column-break-inside: avoid;
+  column-break-inside: avoid;
 }
 
 ul::after {


### PR DESCRIPTION
First column's last li's border-bottom was breaking into the following
column.

Before:
<img width="746" alt="screenshot 2016-04-10 11 47 58" src="https://cloud.githubusercontent.com/assets/1260830/14409462/485557ba-ff14-11e5-8bf7-959fad7a1d83.png">

After:
<img width="742" alt="screenshot 2016-04-10 11 48 31" src="https://cloud.githubusercontent.com/assets/1260830/14409464/4e57c1d4-ff14-11e5-9d6a-545575f9d831.png">

(screenshots taken from Chrome v49.0.2623.110)
