### PR TITLE
Consistant formatting in examples

### DIFF
--- a/index.md
+++ b/index.md
@@ -169,8 +169,8 @@ In your editor:
 ```js
 var assert = require('chai').assert;
 describe('Array', function() {
-  describe('#indexOf()', function () {
-    it('should return -1 when the value is not present', function () {
+  describe('#indexOf()', function() {
+    it('should return -1 when the value is not present', function() {
       assert.equal(-1, [1,2,3].indexOf(5));
       assert.equal(-1, [1,2,3].indexOf(0));
     });


### PR DESCRIPTION
It seems that in most examples the parenthesis are right after then function name without whitespace but in this example there is whitespace.
