### PR TITLE
Fix usage of `done()` on error

### DIFF
--- a/index.md
+++ b/index.md
@@ -223,8 +223,8 @@ describe('User', function() {
     it('should save without error', function(done) {
       var user = new User('Luna');
       user.save(function(err) {
-        if (err) throw err;
-        done();
+        if (err) done(err);
+        else done();
       });
     });
   });


### PR DESCRIPTION
The current example is misleading because when we throw an exception without calling `done()`, the test times out. We need to propagate the error through `done()`.
