### PR TITLE
Clarify landing strip docs

### DIFF
--- a/index.md
+++ b/index.md
@@ -968,7 +968,7 @@ The TAP reporter emits lines for a [Test-Anything-Protocol](http://en.wikipedia.
 
 ### Landing Strip
 
-The 'Landing Strip' reporter is a gimmicky test reporter simulating a plane landing :) unicode ftw
+The Landing Strip (or "landing") reporter is a gimmicky test reporter simulating a plane landing :) unicode ftw
 
 ![landing strip plane reporter](images/reporter-landing.png)
 ![landing strip with failure](images/reporter-landing-fail.png)


### PR DESCRIPTION
It's not clear that the specified value for REPORTER has to be exactly `landing`, not `landingstrip` or something.
