### PR TITLE
Workaround for Backer and Sponsor Icon Sizes in Edge/IE

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -32,6 +32,10 @@ h1 {
   transition: opacity .3s;
 }
 
+#_backers a img, #_sponsors a img {
+  max-height: 64px;
+}
+
 .onload h1, #_backers.onload a, #_sponsors.onload a {
   opacity: 1;
 }


### PR DESCRIPTION
## Bug

Edge/IE seems to have a bug rendering empty backer image icons:

![image](https://cloud.githubusercontent.com/assets/212305/19371605/54109adc-9169-11e6-9a5f-efbbb6f39253.png)

I don't know what is going wrong specifically, but believe it may have something to do with the svg file having a `viewbox` but not having a `width`.
## Fix

Add an explicit `max-height` rule in the css to fix this:

![image](https://cloud.githubusercontent.com/assets/212305/19371565/14a9d0de-9169-11e6-9d31-2d4067ce318c.png)

Tested on Edge and Chrome on windows to confirm everything renders correctly.
