### PR TITLE
Update 'Arrow Function' wording for clarity.

### DIFF
--- a/index.md
+++ b/index.md
@@ -236,7 +236,7 @@ describe('Array', function() {
 
 ## Arrow Functions
 
-Passing [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) ("lambdas") to Mocha is discouraged.  Due to the lexical binding of `this`, such functions are unable to access the Mocha context.  For example, the following code will fail due to the nature of lambdas:
+Passing [arrow functions](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions) ("lambdas") to Mocha is discouraged.  Lambdas lexically bind `this` and cannot access the Mocha context.  For example, the following code will fail:
 
 ```js
 describe('my suite', () => {


### PR DESCRIPTION
(minor doc change).  Saw a surprising number of issues and stack overflow questions about using arrow functions, so updated the documentation to be explicit about the lexical binding of 'this'.