### PR TITLE
Update required node and npm versions

### DIFF
--- a/index.md
+++ b/index.md
@@ -89,7 +89,7 @@ or as a development dependency for your project:
 $ npm install --save-dev mocha
 ```
 
-> To install Mocha v3.0.0 or newer with `npm`, you will need `npm` v1.4.0 or newer.  Additionally, to run Mocha, you will need Node.js v4 or newer.
+> To install Mocha v3.0.0 or newer with `npm`, you will need `npm` v2.14.2 or newer.  Additionally, to run Mocha, you will need Node.js v4 or newer.
 
 Mocha can also be installed via [Bower](http://bower.io) (`bower install mocha`), and is available at [cdnjs](https://cdnjs.com/libraries/mocha).
 

--- a/index.md
+++ b/index.md
@@ -89,7 +89,7 @@ or as a development dependency for your project:
 $ npm install --save-dev mocha
 ```
 
-> To install Mocha v3.0.0 or newer with `npm`, you will need `npm` v1.4.0 or newer.  Additionally, to run Mocha, you will need Node.js v0.10 or newer.
+> To install Mocha v3.0.0 or newer with `npm`, you will need `npm` v1.4.0 or newer.  Additionally, to run Mocha, you will need Node.js v4 or newer.
 
 Mocha can also be installed via [Bower](http://bower.io) (`bower install mocha`), and is available at [cdnjs](https://cdnjs.com/libraries/mocha).
 


### PR DESCRIPTION
This PR updates the documentation to support for node `>=4` and npm `>=2.14.2`.

The current version of `mocha` pulls in dependencies which use arrow functions which fail in earlier versions of node.

See https://travis-ci.org/sirreal/mocha/builds/299600162, where I forked `mocha` and added tests for earlier versions.

If node 4 is required, it seems to make sense to report `npm@2.14.2` as the minimum version since that is what shipped with node v4.