### PR TITLE
add mocha sidebar (VScode extension) to mocha documentation 

### DIFF
--- a/index.md
+++ b/index.md
@@ -1228,6 +1228,21 @@ By default, `mocha` looks for the glob `./test/*.js` and `./test/*.coffee`, so y
 
 The following editor-related packages are available:
 
+### Mocha SideBar (VS code)
+
+[mocha sidebar](https://marketplace.visualstudio.com/items?itemName=maty.vscode-mocha-sidebar) Mocha side bar is the most complete extension in vs code
+
+#### mocha side bar already supports this features
+* [x] see all tests in vscode side bar menu
+* [x] run tests for each level hierarchy from all tests to a single test(and each describer of course) 
+* [x] debug tests for each level hierarchy from all tests to a single test(and each describer of course) 
+* [x] auto run tests on file save
+* [x] see tests results directly on the code 
+* [x] run/debug results directly from the code   
+
+![Demo showing mocha menu operation](https://raw.githubusercontent.com/maty21/mocha-sidebar/master/tutorial.gif)
+
+
 ### TextMate
 
 The Mocha TextMate bundle includes snippets to make writing tests quicker and more enjoyable.  To install the bundle, clone a copy of the [Mocha repo](https://github.com/mochajs/mocha), and run:

--- a/index.md
+++ b/index.md
@@ -1228,17 +1228,17 @@ By default, `mocha` looks for the glob `./test/*.js` and `./test/*.coffee`, so y
 
 The following editor-related packages are available:
 
-### Mocha SideBar (VS code)
+### Mocha Sidebar (VS code)
 
-[mocha sidebar](https://marketplace.visualstudio.com/items?itemName=maty.vscode-mocha-sidebar) Mocha side bar is the most complete extension in vs code
+[Mocha sidebar](https://marketplace.visualstudio.com/items?itemName=maty.vscode-mocha-sidebar) is the most complete mocha extension for vs code.
 
-#### mocha side bar already supports this features
+#### mocha side bar supports the following features
 * [x] see all tests in vscode side bar menu
-* [x] run tests for each level hierarchy from all tests to a single test(and each describer of course) 
-* [x] debug tests for each level hierarchy from all tests to a single test(and each describer of course) 
+* [x] run tests for each level hierarchy from all tests to a single test (and each describe of course) 
+* [x] debug tests for each level hierarchy from all tests to a single test (and each describe of course) 
 * [x] auto run tests on file save
-* [x] see tests results directly on the code 
-* [x] run/debug results directly from the code   
+* [x] see tests results directly in the code editor 
+* [x] run/debug results directly from the code editor  
 
 ![Demo showing mocha menu operation](https://raw.githubusercontent.com/maty21/mocha-sidebar/master/tutorial.gif)
 


### PR DESCRIPTION
this PR adds mocha sideBar to mocha's documentation. under the extensions section.
the extension is currently the most  popular mocha extension for VS code. 
5 start ranked with almost 4k downloads in the last two months   
the extension has lot of features and it well maintained(already have 3 contributers)

so IMO it will be great if you guys will add it to mocha documentation

Tks 







  

